### PR TITLE
Add MeterAsset type to openXDA application typings

### DIFF
--- a/application-typings/lib/OpenXDA.ts
+++ b/application-typings/lib/OpenXDA.ts
@@ -67,6 +67,7 @@ namespace OpenXDA {
 
         // Assets
         export interface Asset { ID: number, VoltageKV: number, AssetKey: string, Description: string, AssetName: string, AssetType: AssetTypeName, Spare:boolean, Channels: Array<Channel> }
+        export interface MeterAsset extends Asset { FaultDetectionLogic: string }
         export interface Breaker extends Asset { ThermalRating: number, Speed: number, TripTime: number, PickupTime: number, TripCoilCondition: number, EDNAPoint?: string, SpareBreakerID?: number, AirGapResistor: boolean }
         export interface Bus extends Asset { }
         export interface CapBank extends Asset {


### PR DESCRIPTION
This is necessary for https://github.com/GridProtectionAlliance/SystemCenter/pull/122