### PR TITLE
SC-52 Fix Table Sort Order

### DIFF
--- a/react-table/src/AdjustableTable/Column.tsx
+++ b/react-table/src/AdjustableTable/Column.tsx
@@ -111,11 +111,11 @@ export function ColumnHeaderWrapper<T>(props: React.PropsWithChildren<IHeaderWra
                 onClick={onClick}
                 onDrag={(e) => {e.stopPropagation()}}
             >
-            {props.sorted && props.asc ? <div 
+            {props.sorted && !props.asc ? <div 
                 style={{ position: 'absolute', width: 25 }}>
                     {SVGIcons.ArrowDropDown} 
                 </div> : null}
-            {props.sorted && !props.asc ? <div 
+            {props.sorted && props.asc ? <div 
                 style={{ position: 'absolute', width: 25 }}>
                     {SVGIcons.ArrowDropUp} 
                 </div> : null}


### PR DESCRIPTION
Reverse the arrow in react-table so ascending and descending aren't flipped.