### PR TITLE
GEM-16

### DIFF
--- a/react-interactive/src/Menue/Application.tsx
+++ b/react-interactive/src/Menue/Application.tsx
@@ -98,9 +98,20 @@ const Applications: React.ForwardRefRenderFunction<IApplicationRefs, React.Props
     const [navBarHeight, setNavBarHeight] = React.useState<number>(40);
 
     React.useLayoutEffect(() => {
-        if ((navBarRef?.current != null) && navBarRef?.current?.offsetHeight !== navBarHeight)
-            setNavBarHeight(navBarRef.current.offsetHeight)
-    }, [props?.children]);
+        if (navBarRef.current == null) return; 
+
+        const handleResize = () => {
+            if (navBarRef.current == null) return;
+            setNavBarHeight(navBarRef.current.offsetHeight);
+        };
+
+        const resizeObserver = new ResizeObserver(handleResize);
+        resizeObserver.observe(navBarRef.current);
+
+        handleResize();
+
+        return () => resizeObserver.disconnect();
+    }, [props?.children]); 
 
     React.useEffect(() => {
         const listener = (evt: any) => forceUpdate();


### PR DESCRIPTION
Added a `ResizeObserver` to the `useLayoutEffect` to accurately get the dimensions of the NavBar.

Something I'd like to note is that,
while testing this fix out along with trying to use the `FowaredRef` in `TrendAP` was that if we are passing in components that are lazy loaded into the `Application` component as children you will need to have a `setTimeout` wrapping the logic to set whatever local state needed from the `FowaredRef` in the `useLayoutEffect` hook. If not you will get HTML properties from the `FowardedRef` that are from before the children components are fully rendered. 