### PR TITLE
Use fa-square-o in SelectTable to represent unselected items

### DIFF
--- a/react-table/src/SelectTable.tsx
+++ b/react-table/src/SelectTable.tsx
@@ -105,10 +105,9 @@ export function SelectTable<T>(props: ISelectTableProps<T>) {
     const tableProps: TableProps<T> = {
         cols: [
             { key: 'gemstone-checkbox', field: props.KeyField, label: '', headerStyle: { width: '4em' }, rowStyle: { width: '4em' }, content: (item: T) => {
-                const index = selected.findIndex(i => i === item[props.KeyField])
-                if ( index > -1)
-                    return <div style={{ marginTop: '16px', textAlign: 'center' }}><i className="fa fa-check-square-o fa-3x"></i></div>
-                return null
+                const index = selected.findIndex(i => i === item[props.KeyField]);
+                const iconClass = index > -1 ? 'fa-check-square-o' : 'fa-square-o';
+                return <div style={{ textAlign: 'center', verticalAlign: 'middle' }}><i className={`fa ${iconClass} fa-3x`}></i></div>;
             }},
             ...props.cols
         ],


### PR DESCRIPTION
By placing an icon in unselected rows, the row size will not change when selecting a row.

![image](https://github.com/GridProtectionAlliance/gpa-gemstone/assets/9203145/01876202-03c8-4eea-be5d-3f55f45c729a)
