### PR TITLE
Fix size for ArrowBackward

### DIFF
--- a/gpa-symbols/src/ReactIcons.tsx
+++ b/gpa-symbols/src/ReactIcons.tsx
@@ -69,7 +69,7 @@ export namespace ReactIcons {
         <polygon points="6.23,20.23 8,22 18,12 8,2 6.23,3.77 14.46,12" />
     </svg>
 
-    export const ArrowBackward: React.FC<IProps> = (props) => <svg xmlns="http://www.w3.org/2000/svg" width={props.Size ?? 24} height="24" viewBox="0 0 24 24" fill={props.Color ?? "currentColor"} stroke={props.Color ?? "currentColor"} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="feather feather-file-text">
+    export const ArrowBackward: React.FC<IProps> = (props) => <svg xmlns="http://www.w3.org/2000/svg" style={{ ...(props.Style ?? {}), width: props.Size ?? 24, height: props.Size ?? 24 }} viewBox="0 0 24 24" fill={props.Color ?? "currentColor"} stroke={props.Color ?? "currentColor"} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="feather feather-file-text">
         <polygon points="17.77,3.77 16,2 6,12 16,22 17.77,20.23 9.54,12" />
     </svg>
 


### PR DESCRIPTION
I missed the ArrowBackward icon when doing the rework to set width and height via the style attribute.