### PR TITLE
Removed return null on no items, body must render for the ref to be a…

### DIFF
--- a/react-table/src/AdjustableTable/Table.tsx
+++ b/react-table/src/AdjustableTable/Table.tsx
@@ -465,8 +465,6 @@ interface IRowProps<T> {
 }
     
 function Rows<T>(props: React.PropsWithChildren<IRowProps<T>>) {
-    if (props.Data.length === 0) return null;
-    
     const onClick = React.useCallback((e: React.MouseEvent<HTMLTableRowElement, MouseEvent>, item: T, index: number) => {
         if (props.OnClick !== undefined)
             props.OnClick(


### PR DESCRIPTION
…ttached to it for width calculations