### PR TITLE
Change default minWidth so that its a more reasonable value

### DIFF
--- a/react-table/src/Table/Table.tsx
+++ b/react-table/src/Table/Table.tsx
@@ -133,7 +133,7 @@ export function Table<T>(props: React.PropsWithChildren<ReactTableProps.ITable<T
         React.Children.forEach(props.children, (element) => {
             if (React.isValidElement(element) && IsColumnProps(element.props)) {
                 if (newMap.get(element.props.Key) != null) console.error("Multiple of the same key detected in table, this will cause issues.");
-                newMap.set(element.props.Key, {minWidth: 100, maxWidth: 1000, width: 100})
+                newMap.set(element.props.Key, {minWidth: 10, maxWidth: 1000, width: 100})
             }
         });
 


### PR DESCRIPTION
With previous default of minWidth, there are common cases where minWidth is smaller than widths specified by devs (~18px comes to mind for buttons). Thus, minWidth would overwrite width if a dev did not specify it. This change makes minWidth smaller, to more properly be a default minimum that doesn't conflict with any current use cases.