### PR TITLE
Width Fix for Stylable Select

### DIFF
--- a/react-forms/src/StylableSelect.tsx
+++ b/react-forms/src/StylableSelect.tsx
@@ -221,6 +221,7 @@ export default function StylableSelect<T>(props: IProps<T>) {
             zIndex: 9999,
             top: `${position.Top}px`,
             left: `${position.Left}px`,
+            minWidth: `${position.Width}px`,
             maxWidth: '100%'
           }}
         >


### PR DESCRIPTION
Added a minWidth to popover div so that the div will at least take the space of the target.