### PR TITLE
Added function to getSearchFilters stored by SearchBar

### DIFF
--- a/react-interactive/src/SearchBar.tsx
+++ b/react-interactive/src/SearchBar.tsx
@@ -460,3 +460,10 @@ function FilterRow<T>(props: IFilterRowProps<T>) {
         </td>
     </tr>;
 }
+
+export const getSearchFilters = (storageID: string) => {
+    const storedFilters = JSON.parse(localStorage.getItem(`${storageID}.Filters`) as string) ?? [];
+    const storedSearch = localStorage.getItem(`${storageID}.Search`) ?? "";
+
+    return [...storedFilters, storedSearch]
+}

--- a/react-interactive/src/SearchBar.tsx
+++ b/react-interactive/src/SearchBar.tsx
@@ -461,7 +461,7 @@ function FilterRow<T>(props: IFilterRowProps<T>) {
     </tr>;
 }
 
-export const getSearchFilters = (storageID: string) => {
+export const GetStoredFilters = (storageID: string) => {
     const storedFilters = JSON.parse(localStorage.getItem(`${storageID}.Filters`) as string) ?? [];
     const storedSearch = localStorage.getItem(`${storageID}.Search`) ?? "";
 

--- a/react-interactive/src/index.tsx
+++ b/react-interactive/src/index.tsx
@@ -24,7 +24,7 @@
 import Modal from './Modal';
 import Warning from './Warning';
 import SearchBar from './SearchBar';
-import { Search } from './SearchBar';
+import { Search, getSearchFilters } from './SearchBar';
 import LoadingScreen from './LoadingScreen';
 import LoadingIcon from './LoadingIcon';
 import { ToolTip } from '@gpa-gemstone/react-forms';
@@ -52,6 +52,7 @@ export {
   Warning,
   SearchBar,
   Search,
+  getSearchFilters,
   LoadingScreen,
   LoadingIcon,
   /**

--- a/react-interactive/src/index.tsx
+++ b/react-interactive/src/index.tsx
@@ -24,7 +24,7 @@
 import Modal from './Modal';
 import Warning from './Warning';
 import SearchBar from './SearchBar';
-import { Search, getSearchFilters } from './SearchBar';
+import { Search, GetStoredFilters } from './SearchBar';
 import LoadingScreen from './LoadingScreen';
 import LoadingIcon from './LoadingIcon';
 import { ToolTip } from '@gpa-gemstone/react-forms';
@@ -52,7 +52,7 @@ export {
   Warning,
   SearchBar,
   Search,
-  getSearchFilters,
+  GetStoredFilters,
   LoadingScreen,
   LoadingIcon,
   /**


### PR DESCRIPTION
Added function to get search filters from local storage. This is especially useful in cases where we want to preselect a record from a list of records that are determined by searchFilters and also prevents an extra call to the search endpoint when a filter is saved. 