### PR TITLE
Pagination-Rework

### DIFF
--- a/gpa-symbols/src/ReactIcons.tsx
+++ b/gpa-symbols/src/ReactIcons.tsx
@@ -365,6 +365,28 @@ export namespace ReactIcons {
             <line x1="12" y1="2" x2="12" y2="22"></line>
         </svg>
 
+    export const ChevronLeft: React.FC<IProps> = (props) =>
+        <svg xmlns="http://www.w3.org/2000/svg" style={{ ...(props.Style ?? {}), width: props.Size ?? props.Style?.width ?? 24, height: props.Size ?? props.Style?.height ?? 24, }} viewBox="0 0 24 24" fill="none" stroke={props.Color ?? "currentColor"} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="feather feather-chevron-left">
+            <polyline points="15 18 9 12 15 6"></polyline>
+        </svg>
+
+    export const ChevronRight: React.FC<IProps> = (props) =>
+        <svg xmlns="http://www.w3.org/2000/svg" style={{ ...(props.Style ?? {}), width: props.Size ?? props.Style?.width ?? 24, height: props.Size ?? props.Style?.height ?? 24, }} viewBox="0 0 24 24" fill="none" stroke={props.Color ?? "currentColor"} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="feather feather-chevron-right">
+            <polyline points="9 18 15 12 9 6"></polyline>
+        </svg>
+
+    export const DoubleChevronLeft: React.FC<IProps> = (props) =>
+        <svg xmlns="http://www.w3.org/2000/svg" style={{ ...(props.Style ?? {}), width: props.Size ?? props.Style?.width ?? 24, height: props.Size ?? props.Style?.height ?? 24, }} viewBox="0 0 24 24" fill="none" stroke={props.Color ?? "currentColor"} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="feather feather-chevrons-left">
+            <polyline points="11 17 6 12 11 7"></polyline>
+            <polyline points="18 17 13 12 18 7"></polyline>
+        </svg>
+
+    export const DoubleChevronRight: React.FC<IProps> = (props) =>
+        <svg xmlns="http://www.w3.org/2000/svg" style={{ ...(props.Style ?? {}), width: props.Size ?? props.Style?.width ?? 24, height: props.Size ?? props.Style?.height ?? 24, }} viewBox="0 0 24 24" fill="none" stroke={props.Color ?? "currentColor"} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="feather feather-chevrons-right">
+            <polyline points="13 17 18 12 13 7"></polyline>
+            <polyline points="6 17 11 12 6 7"></polyline>
+        </svg>
+
     export const ChevronDown: React.FC<IProps> = (props) =>
         <svg xmlns="http://www.w3.org/2000/svg" style={{ ...(props.Style ?? {}), width: props.Size ?? props.Style?.width ?? 24, height: props.Size ?? props.Style?.height ?? 24, }} viewBox="0 0 24 24" fill="none" stroke={props.Color ?? "currentColor"} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="feather feather-chevron-down">
             <polyline points="6 9 12 15 18 9"></polyline>

--- a/helper-functions/src/useGetContainerPosition.tsx
+++ b/helper-functions/src/useGetContainerPosition.tsx
@@ -30,6 +30,7 @@ import * as React from 'react'
  * - `left`: Distance from the left of the viewport to the left of the container.
  * - `height`: Height of the container.
  * - `width`: Width of the container.
+ * - `scrollWidth`: Scroll Width of the container.
  * - `x`: Horizontal position of the container relative to the viewport.
  * - `y`: Vertical position of the container relative to the viewport.
  * - `bottom`: Distance from the top of the viewport to the bottom of the container.
@@ -40,7 +41,10 @@ export const useGetContainerPosition = (containerRef: React.MutableRefObject<HTM
     const [top, setTop] = React.useState<number>(0);
     const [left, setLeft] = React.useState<number>(0);
     const [height, setHeight] = React.useState<number>(0);
+
     const [width, setWidth] = React.useState<number>(0);
+    const [scrollWidth, setScrollWidth] = React.useState<number>(0);
+
     const [x, setX] = React.useState<number>(0);
     const [y, setY] = React.useState<number>(0);
     const [bottom, setBottom] = React.useState<number>(0);
@@ -52,25 +56,27 @@ export const useGetContainerPosition = (containerRef: React.MutableRefObject<HTM
         const handleResize = () => {
             if (containerRef.current == null) return
             const newSize = containerRef.current.getBoundingClientRect()
+            const newScrollWidth = containerRef.current.scrollWidth;
             if (newSize.top !== top) setTop(newSize.top);
             if (newSize.left !== left) setLeft(newSize.left);
             if (newSize.height !== height) setHeight(newSize.height);
             if (newSize.width !== width) setWidth(newSize.width);
+            if (newScrollWidth !== scrollWidth) setScrollWidth(newScrollWidth);
             if (newSize.x !== x) setX(newSize.x);
             if (newSize.y !== y) setY(newSize.y);
             if (newSize.bottom !== bottom) setBottom(newSize.bottom);
             if (newSize.right !== right) setRight(newSize.right);
         }
-        
+
         const resizeObserver = new ResizeObserver(handleResize);
         resizeObserver.observe(containerRef.current);
 
         handleResize();
 
         return () => {
-            resizeObserver.disconnect(); 
+            resizeObserver.disconnect();
         };
     })
 
-    return {top, left, height, width, x, y, bottom, right}
+    return { top, left, height, width, x, y, bottom, right, scrollWidth }
 }

--- a/react-table/src/Paging.tsx
+++ b/react-table/src/Paging.tsx
@@ -20,77 +20,157 @@
 //       Generated original version of source code.
 //
 //  ******************************************************************************************************
+import { ReactIcons } from '@gpa-gemstone/gpa-symbols';
+import { useGetContainerPosition } from '@gpa-gemstone/helper-functions';
 import * as React from 'react';
 
 export interface IProps {
     Current: number,
     Total: number,
-    SetPage: (p: number) => void
+    SetPage: (p: number) => void,
 }
 
-export default function (props: IProps) {
-    const [pages, setPages] = React.useState<number[]>([]);
+const defaultMaxPagesToShow = 7;
 
-    const nPages = 7;
-    const minPg = React.useMemo(() => {
-        const min = Math.min(...pages);
-        if (isFinite(min) && !isNaN(min)) return min;
-        return 0;
-    }, [pages]);
-    const maxPg = React.useMemo(() => {
-        const max = Math.max(...pages);
-        if (isFinite(max) && !isNaN(max)) return max;
-        return 0
-    }, [pages]);
+const Paging = (props: IProps) => {
+    const containerRef = React.useRef<HTMLDivElement | null>(null);
+    const { scrollWidth, width } = useGetContainerPosition(containerRef);
+
+    const [pagesToShow, setPagesToShow] = React.useState<number[]>([]);
+    const [maxPagesToShow, setMaxPagesToShow] = React.useState<number>(defaultMaxPagesToShow);
+
+    const minPageToShow = React.useMemo(() => {
+        const min = Math.min(...pagesToShow);
+        if (!isFinite(min) || isNaN(min)) return 0;
+        return min;
+    }, [pagesToShow]);
+
+    const maxPageToShow = React.useMemo(() => {
+        const max = Math.max(...pagesToShow);
+        if (!isFinite(max) || isNaN(max)) return 0;
+        return max
+    }, [pagesToShow]);
 
     React.useEffect(() => {
-        const display = [];
-        let p = Math.max(props.Current - Math.floor(nPages / 2), 1);
-        if (props.Total - p < nPages)
-            p = Math.max(props.Total - nPages + 1,1);
+        const newPagesToShow = [];
+        let startPage = Math.max(props.Current - Math.floor(maxPagesToShow / 2), 1);
 
-        while (p <= props.Total && display.length < nPages) {
-            display.push(p);
-            p = p + 1;
+        if (props.Total - startPage < maxPagesToShow)
+            startPage = Math.max(props.Total - maxPagesToShow + 1, 1);
+
+        while (startPage <= props.Total && newPagesToShow.length < maxPagesToShow) {
+            newPagesToShow.push(startPage);
+            startPage = startPage + 1;
         }
-        setPages(display);
-    }, [props.Total, props.Current]);
 
-    return <ul className="pagination justify-content-center">
-        <li className={"page-item" + (minPg <= 1 ? ' disabled' : "")} key="previous">
-            <a className="page-link" onClick={() => {
-                if (minPg > 1)
-                    props.SetPage(Math.max(props.Current - nPages,1))
-            }}>Previous</a>
-        </li>
-        {minPg > 2 ? <>
-            <li className={"page-item"} key={"1"}>
-                <a className={"page-link"} onClick={() => props.SetPage(1)}>1</a>
+        setPagesToShow(newPagesToShow);
+    }, [props.Total, props.Current, width, scrollWidth, maxPagesToShow]);
+
+    //Effect to decrement maxPagesToShow if we are overflowing
+    React.useLayoutEffect(() => {
+        if (scrollWidth > width)
+            setMaxPagesToShow(prev => Math.max(prev - 1, 1))
+
+    }, [width, scrollWidth])
+
+    //Effect to increment maxPagesToShow if we have enough space
+    React.useLayoutEffect(() => {
+        if (maxPagesToShow >= defaultMaxPagesToShow || containerRef.current == null) return
+
+        const childArray = Array.from(containerRef.current.children);
+
+        // Sum widths of all <li> elements
+        const trueWidth = childArray.reduce((sum, child) => sum + (child as HTMLElement).offsetWidth, 0);
+        const availableWidth = width - trueWidth;
+
+        const estimatedButtonWidthWithTolerance = 50;
+
+        if (availableWidth >= estimatedButtonWidthWithTolerance) 
+            setMaxPagesToShow(prev => Math.min(defaultMaxPagesToShow, prev + 1));
+        
+    }, [width, maxPagesToShow]);
+
+
+    const showLeftBlock = maxPagesToShow < defaultMaxPagesToShow
+        ? minPageToShow !== 1
+        : minPageToShow > 2;
+
+    const showRightBlock = maxPagesToShow < defaultMaxPagesToShow
+        ? maxPageToShow !== props.Total
+        : maxPageToShow + 2 <= props.Total;
+
+    return (
+        <ul className="pagination justify-content-center" ref={containerRef as any}>
+
+            <li className={"page-item" + (minPageToShow <= 1 ? ' disabled' : "")} key="previous" style={{ cursor: 'pointer' }}>
+                <a className="page-link" onClick={() => {
+                    if (minPageToShow > 1)
+                        props.SetPage(Math.max(props.Current - defaultMaxPagesToShow, 1))
+                }}>
+                    <ReactIcons.DoubleChevronLeft Size={15} />
+                </a>
             </li>
-            <li className={"page-item disabled"} key={"skip-1"}>
-                <a className={"page-link"}>...</a>
+
+            <li className={"page-item" + (props.Current <= 1 ? ' disabled' : "")} key="step-previous" style={{ cursor: 'pointer' }}>
+                <a className="page-link" onClick={() => {
+                    if (props.Current > 1)
+                        props.SetPage(props.Current - 1)
+                }}>
+                    <ReactIcons.ChevronLeft Size={15} />
+                </a>
             </li>
-        </> : null}
-        {pages.map((p) => <li className={"page-item" + (p == props.Current ? " active" : "")} key={p}>
-            <a className={"page-link"} onClick={() => props.SetPage(p)}>{p}</a>
-        </li>)}
-        {maxPg + 2 <= props.Total ? <>
-            <li className={"page-item disabled"} key={"skip-2"}>
-                <a className={"page-link"}>...</a>
+
+            {showLeftBlock ? <>
+                <li className={"page-item"} key={"1"} style={{ cursor: 'pointer' }}>
+                    <a className={"page-link"} onClick={() => props.SetPage(1)}>
+                        1
+                    </a>
+                </li>
+                <li className={"page-item disabled"} key={"skip-1"} >
+                    <a className={"page-link"}>...</a>
+                </li>
+            </> : null}
+
+            {pagesToShow.map((p) =>
+                <li className={"page-item" + (p == props.Current ? " active" : "")} key={p} style={{ cursor: 'pointer' }}>
+                    <a className={"page-link"} onClick={() => props.SetPage(p)}>
+                        {p}
+                    </a>
+                </li>)}
+
+            {showRightBlock ? <>
+                <li className={"page-item disabled"} key={"skip-2"}>
+                    <a className={"page-link"}>...</a>
+                </li>
+                <li className={"page-item"} key={props.Total} style={{ cursor: 'pointer' }}>
+                    <a className={"page-link"} onClick={() => props.SetPage(props.Total)}>
+                        {props.Total}
+                    </a>
+                </li>
+            </> : null}
+
+            <li className={"page-item" + (props.Current >= props.Total ? ' disabled' : "")} key="step-next" style={{ cursor: 'pointer' }}>
+                <a className="page-link" onClick={() => {
+                    if (props.Current < props.Total)
+                        props.SetPage(props.Current + 1)
+                }}
+                >
+                    <ReactIcons.ChevronRight Size={15} />
+                </a>
             </li>
-            <li className={"page-item"} key={props.Total}>
-                <a className={"page-link"} onClick={() => props.SetPage(props.Total)}>{props.Total}</a>
+
+            <li className={"page-item" + (maxPageToShow == props.Total ? ' disabled' : "")} key={'next'} style={{ cursor: 'pointer' }}>
+                <a className="page-link" onClick={() => {
+                    if (maxPageToShow < props.Total)
+                        props.SetPage(Math.min(props.Current + defaultMaxPagesToShow, props.Total))
+                }}
+                >
+                    <ReactIcons.DoubleChevronRight Size={15} />
+                </a>
             </li>
-        </> : null}
-        <li className={"page-item" + (maxPg == props.Total ? ' disabled' : "")} key={'next'}>
-            <a className="page-link" onClick={() => {
-                if (maxPg < props.Total)
-                    props.SetPage(Math.min(props.Current + nPages, props.Total))
-            }
-            }>Next</a>
-        </li>
-    </ul>
+        </ul>
+    )
 
 }
 
-
+export default Paging;


### PR DESCRIPTION
Removed Previous/Next buttons in favor of two chevron icons to step by 1 and step by the default block size(7). 
Added logic to dynamically adjust the max number of pages to show at once based on the available width.