### PR TITLE
Line legend performance

### DIFF
--- a/react-graph/src/LineLegend.tsx
+++ b/react-graph/src/LineLegend.tsx
@@ -1,4 +1,4 @@
-﻿// ******************************************************************************************************
+// ******************************************************************************************************
 //  LineLegend.tsx - Gbtc
 //
 //  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
@@ -53,6 +53,7 @@ function LineLegend(props: IProps) {
 
     React.useEffect(() => {
         return () => {
+            context.UnRegisterFontSize(guid);
             context.RequestLegendWidth(-1, guid);
         }
     }, []);
@@ -90,13 +91,7 @@ function LineLegend(props: IProps) {
         }
         context.RegisterFontSize(guid, newFontSize)
         setUseMultiLine(useML);
-    }, [label, legendWidth, legendHeight, props.size, props.hasNoData, guid, context.RegisterFontSize]);
-
-    React.useEffect(() => {
-        return () => {
-            context.UnRegisterFontSize(guid)
-        }
-    }, [guid])
+    }, [label, legendWidth, legendHeight]);
 
     return (
         <div style={{ height: legendHeight, width: legendWidth }} ref={containerRef}>

--- a/react-graph/src/LineLegend.tsx
+++ b/react-graph/src/LineLegend.tsx
@@ -1,4 +1,4 @@
-// ******************************************************************************************************
+﻿// ******************************************************************************************************
 //  LineLegend.tsx - Gbtc
 //
 //  Copyright © 2023, Grid Protection Alliance.  All Rights Reserved.
@@ -77,7 +77,7 @@ function LineLegend(props: IProps) {
         context.RequestLegendWidth(textWidth + nonTextualWidth, guid);
 
         while (newFontSize > 0.4 && (textWidth > availableWidth - nonTextualWidth || textHeight > legendHeight)) {
-            newFontSize -= 0.05;
+            newFontSize -= 0.1;
 
             textWidth = GetTextWidth(fontFamily, `${newFontSize}em`, label, `${cssStyle}`, `${legendHeight}px`, `${useML ? 'normal' : undefined}`, `${availableWidth - nonTextualWidth}px`);
             textHeight = GetTextHeight(fontFamily, `${newFontSize}em`, label, `${cssStyle}`, `${availableWidth - nonTextualWidth}px`, `${useML ? 'normal' : undefined}`);
@@ -89,6 +89,7 @@ function LineLegend(props: IProps) {
                 textWidth = GetTextWidth(fontFamily, `${newFontSize}em`, label, `${cssStyle}`, `${legendHeight}px`, `${useML ? 'normal' : undefined}`, `${availableWidth - nonTextualWidth}px`);
             }
         }
+
         context.RegisterFontSize(guid, newFontSize)
         setUseMultiLine(useML);
     }, [label, legendWidth, legendHeight]);


### PR DESCRIPTION
Testing performance of plot, the amount of time lost to passive effects for line legend was pretty significant. In particular, the use effect that measures text width contributed significant time. A few different minor adjustments were tested for impact on average timings:

Current:  5.0ms 
Reversed Linear Search: 9.0 ms
Binary Search: 7.6 ms
Reduction of Text Test Granularity: 3.0 ms (this is what this PR implements)

 Testing with around 315 channels with no data resulted in ~8.2s of load time, ~5.5s were passive effects. With the changes in this PR, we observe ~6.7s of total load time and ~3.9s of passive effects. These total timings are rough estimates due to low sample size.

There are other gains to be made. This use effect appears to fire twice during loading, as well as unneeded rerenders caused by context changes that could be cut down on. The two fires appear necessary for the measure -> adjust design of automatic legend widths and heights, but there is a gain there if we could either disable this functionality in some cases or detect that there is no change from the maximum. As for the context changes, I recommend for future work that we put the setter like functions of the context away in a useRef or something similar, so that changes to the references of the functions don't cause children to re-render.