### PR TITLE
Fix for Config Columns 

### DIFF
--- a/react-table/src/ConfigurableTable/ConfigurableTable.tsx
+++ b/react-table/src/ConfigurableTable/ConfigurableTable.tsx
@@ -92,6 +92,10 @@ export default function ConfigurableTable<T>(props: React.PropsWithChildren<ITab
     }, []);
 
     React.useEffect(() => {
+        setColumns(getKeyMappings());
+    }, [props.children]);
+
+    React.useEffect(() => {
         if (props.OnSettingsChange !== undefined) props.OnSettingsChange(showSettings);
     }, [showSettings]);
 
@@ -99,10 +103,6 @@ export default function ConfigurableTable<T>(props: React.PropsWithChildren<ITab
         saveLocal();
     }, [columns]);
 
-    /**
-    *
-    * @returns
-    */
     function saveLocal() {
         if (props.LocalStorageKey === undefined) return;
         const currentState = localStorage.getItem(props.LocalStorageKey);


### PR DESCRIPTION
<h3> Description </h3>

Some tables have functions to render their columns (like a `.map(() => {})`) instead of passing cols in directly.  
In this case the `ConfigurableTable` did not notice the updates to `props.children` as the columns came in.  
This fix added a `useEffect()` to update the `cols` array when `props.children` changes.  

This problem was discovered on the External Table Test table which uses the `ResultsDisplay` component.

> [!NOTE] 
> **Testing**
>1. Navigate to External Tables </br>
>2. Select a Row (ex. Meters) </br>
>3. Click `[ Test Table Query ]` button and `[ Next ]` </br>
>4. Click a Row (ex. 02-08-24-Test) and `[ Save ]` </br>
>5. Table should be fully populated and functional </br>