### PR TITLE
Fix ConfigurableTable LocalStorage Bugs

### DIFF
--- a/react-table/src/ConfigurableTable/ConfigurableTable.tsx
+++ b/react-table/src/ConfigurableTable/ConfigurableTable.tsx
@@ -75,7 +75,7 @@ export default function ConfigurableTable<T>(props: React.PropsWithChildren<ITab
                     Default: element.props.Default ?? false,
                     Enabled: false,
                 };          // use local if it has anything
-                baseCol.Enabled = localKeys.length > 1 ? localKeys.includes(key) : isEnabled(baseCol);
+                baseCol.Enabled = localKeys.length > 0 ? localKeys.includes(key) : isEnabled(baseCol);
                 updated.set(key, baseCol);
             }
         });
@@ -110,13 +110,16 @@ export default function ConfigurableTable<T>(props: React.PropsWithChildren<ITab
 
     function saveLocal() {
         if (props.LocalStorageKey === undefined) return;
-        const currentState = localStorage.getItem(props.LocalStorageKey);
-        let currentKeys: string[] = [];
-        if (currentState !== null) currentKeys = currentState.split(',');
 
+        const currentState = localStorage.getItem(props.LocalStorageKey);
         const allKeys = Array.from(columns.keys());
+        let currentKeys: string[] = [];
+
+        if (currentState !== null) currentKeys = currentState.split(',');
         currentKeys = currentKeys.filter((k) => !allKeys.includes(k));
-        const enabled = Array.from(columns.keys()).filter((k) => columns.get(k)?.Enabled);
+
+        const enabled = allKeys.filter((k) => columns.get(k)?.Enabled);
+
         currentKeys.push(...enabled);
         localStorage.setItem(props.LocalStorageKey, currentKeys.join(','));
     }


### PR DESCRIPTION
<h3> ConfigTable Fix </h3>
<h4> Description </h4>
Some implementaions of ConfigTable allow the children to change the columns, so the patch that added the useEffect() to monitor children was needed. However this update caused too many updates to localStorage, reading and setting it so frequently it was useless. This now makes more thorough checks of local storage as it adds columns to component states.
<br/>
<br/>

> [!NOTE]
>  **Testing**
> _There are two tables relevant, one on Meter is more standard and the other on External Table is rendered with a `.map()` for the children._
> 1. Go to SystemCenter
> 2. Go to Meter > Select a Meter
> 3. Go to Event Channels
> 4. Remove some columns from selector
> 5. Verify they do no repopulate when, rows have internal changes, rows are deleted, table is sorted, page is refreshed, page is gone away from and gone back to
> 6. Add some rows and test default button for functionality
> 7. Go to External Tables > Meters > Test Table Query > Next > Make a selection > Save
> 8. Repeat step 4-6