### PR TITLE
ConfigurableTable Fix: Add a base case for when localstorage key is just created

### DIFF
--- a/react-table/src/ConfigurableTable/ConfigurableTable.tsx
+++ b/react-table/src/ConfigurableTable/ConfigurableTable.tsx
@@ -121,7 +121,7 @@ export default function ConfigurableTable<T>(props: React.PropsWithChildren<ITab
         const enabled = allKeys.filter((k) => columns.get(k)?.Enabled);
 
         currentKeys.push(...enabled);
-        localStorage.setItem(props.LocalStorageKey, currentKeys.join(','));
+        (currentKeys.length == 0 && currentState == null) ? null : localStorage.setItem(props.LocalStorageKey, currentKeys.join(','));
     }
 
     function changeColumns(key: string) {


### PR DESCRIPTION
The issue is that, on first load localstorage has its key, and contains `""` so `length > 0` returns true and evaluates the wrong columns. Now it explicitly checks for this base case