### PR TITLE
SearchableSelectFocus

### DIFF
--- a/react-forms/src/SearchableSelect.tsx
+++ b/react-forms/src/SearchableSelect.tsx
@@ -170,11 +170,6 @@ export default function SearchableSelect<T>(props: IProps<T>) {
                     value={search}
                     onChange={(d) => setSearch(d.target.value)}
                     onBlur={() => handleSetSearch()}
-                    onClick={(evt) => {
-                        evt.preventDefault();
-                        evt.stopPropagation();
-                        setSearch('');
-                    }}
                     disabled={props.Disabled ?? false}
                 />
                 {loading ?

--- a/react-forms/src/SearchableSelect.tsx
+++ b/react-forms/src/SearchableSelect.tsx
@@ -95,6 +95,7 @@ export default function SearchableSelect<T>(props: IProps<T>) {
     const [searchOptions, setSearchOptions] = React.useState<IStylableOptionOverride[]>([]);
     const [loading, setLoading] = React.useState<boolean>(false);
     const [currentLabel, setCurrentLabel] = React.useState<string | null>(null);
+    const inputRef = React.useRef<HTMLInputElement>(null);
 
     const setter = React.useCallback((record: T, selectedOption: IStylableOption) => {
         const selectedOptionCasted = selectedOption as IStylableOptionOverride; //we can safely cast here because we control the options going in.. 
@@ -163,6 +164,7 @@ export default function SearchableSelect<T>(props: IProps<T>) {
             Label: "", //Label doesnt matter in this case because you cant select this option
             Element: <div className='input-group'>
                 <input
+                    ref={inputRef}
                     type="text"
                     className={`form-control ${(props.Valid?.(props.Field) ?? true) ? '' : 'border-danger'}`}
                     value={search}
@@ -229,6 +231,10 @@ export default function SearchableSelect<T>(props: IProps<T>) {
         BtnStyle={props.BtnStyle}
         Valid={props.Valid}
         Feedback={props.Feedback}
-        OnSelectedOptionContainerClick={() => setSearch('')}
+        OnDropdownOpen={() => {
+            setSearch('');
+            inputRef.current?.focus();
+        }}
+        OnDropdownClose={() => inputRef.current?.blur()}
     />;
 }

--- a/react-forms/src/StylableSelect.tsx
+++ b/react-forms/src/StylableSelect.tsx
@@ -103,9 +103,13 @@ interface IProps<T> {
     */
   BtnStyle?: React.CSSProperties
   /**
-   * Click handler for the button holding the selected value
+   * Callback fired after the dropdown opens and its contents are rendered
    */
-  OnSelectedOptionContainerClick?: (evt: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+  OnDropdownOpen?: () => void;
+  /**
+   * Callback fired after the dropdown closes
+   */
+  OnDropdownClose?: () => void;
 }
 
 export default function StylableSelect<T>(props: IProps<T>) {
@@ -147,6 +151,11 @@ export default function StylableSelect<T>(props: IProps<T>) {
       };
     }
 
+  }, [show]);
+
+  React.useEffect(() => {
+    if (show) props.OnDropdownOpen?.();
+    else props.OnDropdownClose?.();
   }, [show]);
 
   // Handle showing and hiding of the dropdown.
@@ -228,10 +237,10 @@ export default function StylableSelect<T>(props: IProps<T>) {
           ...(props.BtnStyle ?? {})
         }}
         className={`dropdown-toggle form-control ${(props.Valid?.(props.Field) ?? true) ? '' : 'is-invalid'}`}
+        onMouseDown={(evt) => evt.preventDefault()}
         onClick={(evt) => {
           HandleShow(evt);
           if(props.Disabled ?? false) return;
-          if (props.OnSelectedOptionContainerClick != null) props.OnSelectedOptionContainerClick(evt);
         }}
 
       >

--- a/react-forms/src/__tests__/SearchableSelect.test.tsx
+++ b/react-forms/src/__tests__/SearchableSelect.test.tsx
@@ -225,7 +225,7 @@ describe('SearchableSelect', () => {
 
             // Click the input to simulate focus
             await act(async () => {
-                fireEvent.click(input);
+                fireEvent.mouseDown(input);
             });
 
             expect(input).toHaveValue('');


### PR DESCRIPTION
Cleanup focus behavior in SearchableSelect so that the search input will be in focus whenever the dropdown is clicked or the input itself is clicked. 