### PR TITLE
Populate data table in case of uninitiated slice

### DIFF
--- a/common-pages/src/SearchBar.tsx
+++ b/common-pages/src/SearchBar.tsx
@@ -23,7 +23,7 @@
 // ******************************************************************************************************
 
 import * as React from 'react';
-import { GenericSlice, SearchBar as GenericSearchBar, Search } from '@gpa-gemstone/react-interactive';
+import { GenericSlice, SearchBar as GenericSearchBar, Search, IsSearchBarFiltersEqual } from '@gpa-gemstone/react-interactive';
 import { OpenXDA, SystemCenter, Application } from '@gpa-gemstone/application-typings';
 import { useDispatch, useSelector } from 'react-redux';
 import { Dispatch } from '@reduxjs/toolkit';
@@ -70,6 +70,12 @@ export namespace DefaultSearch {
         const ascending = useSelector(props.Slice.Ascending)
         const data: SystemCenter.Types.DetailedMeter[] = useSelector(props.Slice.SearchResults);
 
+        const FilterEqualityOverride = (a: Search.IFilter<SystemCenter.Types.DetailedMeter>[], b: Search.IFilter<SystemCenter.Types.DetailedMeter>[]) => {
+            if (searchStatus === 'uninitiated')
+                dispatch(props.Slice.DBSearch({filter: []}))
+            return IsSearchBarFiltersEqual(a, b);   
+        }
+
         React.useEffect(() => {
           return props.GetAddlFields(setAddlFieldCols);
         }, []);
@@ -91,6 +97,7 @@ export namespace DefaultSearch {
             ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Meter(s)'}
             GetEnum={props.GetEnum}
             StorageID={props.StorageID}
+            OverrideFilterEquality={FilterEqualityOverride}
         >
             {props.children}
         </GenericSearchBar>
@@ -119,6 +126,12 @@ export namespace DefaultSearch {
             { label: 'Description', key: 'Description', type: 'string', isPivotField: false },
         ]; 
 
+        const FilterEqualityOverride = (a: Search.IFilter<SystemCenter.Types.DetailedLocation>[], b: Search.IFilter<SystemCenter.Types.DetailedLocation>[]) => {
+            if (searchStatus === 'uninitiated')
+                dispatch(props.Slice.DBSearch({filter: []}))
+            return IsSearchBarFiltersEqual(a, b);   
+        }
+
         React.useEffect(() => {
           return props.GetAddlFields(setAddlFieldCols);
         }, []);
@@ -138,6 +151,7 @@ export namespace DefaultSearch {
             ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + '  Substation(s)'}
             GetEnum={props.GetEnum}
             StorageID={props.StorageID}
+            OverrideFilterEquality={FilterEqualityOverride}
         >
             {props.children}
         </GenericSearchBar>
@@ -168,6 +182,12 @@ export namespace DefaultSearch {
             { label: 'Description', key: 'Description', type: 'string', isPivotField: false },
         ];
 
+        const FilterEqualityOverride = (a: Search.IFilter<SystemCenter.Types.DetailedAsset>[], b: Search.IFilter<SystemCenter.Types.DetailedAsset>[]) => {
+            if (searchStatus === 'uninitiated')
+                dispatch(props.Slice.DBSearch({filter: []}))
+            return IsSearchBarFiltersEqual(a, b);   
+        }
+
         React.useEffect(() => {
           return props.GetAddlFields(setAddlFieldCols);
         }, []);
@@ -187,6 +207,7 @@ export namespace DefaultSearch {
             ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Transmission Asset(s)'}
             GetEnum={props.GetEnum}
             StorageID={props.StorageID}
+            OverrideFilterEquality={FilterEqualityOverride}
         >
             {props.children}
         </GenericSearchBar>
@@ -214,6 +235,12 @@ export namespace DefaultSearch {
             { label: 'Show in Email Subscription', key: 'DisplayEmail', type: 'boolean', isPivotField: false },
         ];
 
+        const FilterEqualityOverride = (a: Search.IFilter<OpenXDA.Types.AssetGroup>[], b: Search.IFilter<OpenXDA.Types.AssetGroup>[]) => {
+            if (searchStatus === 'uninitiated')
+                dispatch(props.Slice.DBSearch({filter: []}))
+            return IsSearchBarFiltersEqual(a, b);   
+        }
+
         React.useEffect(() => {
           return props.GetAddlFields(setAddlFieldCols);
         }, []);
@@ -233,6 +260,7 @@ export namespace DefaultSearch {
             ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Asset Group(s)'}
             GetEnum={props.GetEnum}
             StorageID={props.StorageID}
+            OverrideFilterEquality={FilterEqualityOverride}
         >
             {props.children}
         </GenericSearchBar>
@@ -257,6 +285,12 @@ export namespace DefaultSearch {
             { label: 'Email', key: 'Email', type: 'string', isPivotField: false },    
         ];
 
+        const FilterEqualityOverride = (a: Search.IFilter<Application.Types.iUserAccount>[], b: Search.IFilter<Application.Types.iUserAccount>[]) => {
+            if (searchStatus === 'uninitiated')
+                dispatch(props.Slice.DBSearch({filter: []}))
+            return IsSearchBarFiltersEqual(a, b);   
+        }
+
         React.useEffect(() => {
           return props.GetAddlFields(setAddlFieldCols);
         }, []);
@@ -276,6 +310,7 @@ export namespace DefaultSearch {
             ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' User(s)'}
             GetEnum={props.GetEnum}
             StorageID={props.StorageID}
+            OverrideFilterEquality={FilterEqualityOverride}
         >
             {props.children}
         </GenericSearchBar>
@@ -296,11 +331,18 @@ export namespace DefaultSearch {
         const [addlFieldCols, setAddlFieldCols] = React.useState<Search.IField<OpenXDA.Types.Customer>[]>([]);
         const addlFilters = useStringMemonization<Search.IFilter<OpenXDA.Types.Customer>[]|undefined>(props.AddlFilters);
         
+        
         const dispatch = useDispatch<Dispatch<any>>();
         const searchStatus = useSelector(props.Slice.SearchStatus)
         const sortField = useSelector(props.Slice.SortField)
         const ascending = useSelector(props.Slice.Ascending)
         const data: OpenXDA.Types.Customer[] = useSelector(props.Slice.SearchResults);
+
+        const FilterEqualityOverride = (a: Search.IFilter<OpenXDA.Types.Customer>[], b: Search.IFilter<OpenXDA.Types.Customer>[]) => {
+            if (searchStatus === 'uninitiated')
+                dispatch(props.Slice.DBSearch({filter: []}))
+            return IsSearchBarFiltersEqual(a, b);   
+        }
 
         React.useEffect(() => {
           return props.GetAddlFields(setAddlFieldCols);
@@ -321,6 +363,7 @@ export namespace DefaultSearch {
             ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Customer(s)'}
             GetEnum={props.GetEnum}
             StorageID={props.StorageID}
+            OverrideFilterEquality={FilterEqualityOverride}
         >
             {props.children}
         </GenericSearchBar>

--- a/common-pages/src/SearchBar.tsx
+++ b/common-pages/src/SearchBar.tsx
@@ -70,11 +70,9 @@ export namespace DefaultSearch {
         const ascending = useSelector(props.Slice.Ascending)
         const data: SystemCenter.Types.DetailedMeter[] = useSelector(props.Slice.SearchResults);
 
-        const FilterEqualityOverride = (a: Search.IFilter<SystemCenter.Types.DetailedMeter>[], b: Search.IFilter<SystemCenter.Types.DetailedMeter>[]) => {
-            if (searchStatus === 'uninitiated')
-                dispatch(props.Slice.DBSearch({filter: []}))
-            return IsSearchBarFiltersEqual(a, b);   
-        }
+        const FilterEqualityOverride = React.useCallback((a: Search.IFilter<SystemCenter.Types.DetailedMeter>[], b: Search.IFilter<SystemCenter.Types.DetailedMeter>[]) => {
+            return searchStatus === 'uninitiated' ? false : IsSearchBarFiltersEqual(a, b);   
+        },[searchStatus])
 
         React.useEffect(() => {
           return props.GetAddlFields(setAddlFieldCols);
@@ -126,11 +124,9 @@ export namespace DefaultSearch {
             { label: 'Description', key: 'Description', type: 'string', isPivotField: false },
         ]; 
 
-        const FilterEqualityOverride = (a: Search.IFilter<SystemCenter.Types.DetailedLocation>[], b: Search.IFilter<SystemCenter.Types.DetailedLocation>[]) => {
-            if (searchStatus === 'uninitiated')
-                dispatch(props.Slice.DBSearch({filter: []}))
-            return IsSearchBarFiltersEqual(a, b);   
-        }
+        const FilterEqualityOverride = React.useCallback((a: Search.IFilter<SystemCenter.Types.DetailedLocation>[], b: Search.IFilter<SystemCenter.Types.DetailedLocation>[]) => {
+            return searchStatus === 'uninitiated' ? false : IsSearchBarFiltersEqual(a, b);
+        },[searchStatus])
 
         React.useEffect(() => {
           return props.GetAddlFields(setAddlFieldCols);
@@ -182,11 +178,9 @@ export namespace DefaultSearch {
             { label: 'Description', key: 'Description', type: 'string', isPivotField: false },
         ];
 
-        const FilterEqualityOverride = (a: Search.IFilter<SystemCenter.Types.DetailedAsset>[], b: Search.IFilter<SystemCenter.Types.DetailedAsset>[]) => {
-            if (searchStatus === 'uninitiated')
-                dispatch(props.Slice.DBSearch({filter: []}))
-            return IsSearchBarFiltersEqual(a, b);   
-        }
+        const FilterEqualityOverride = React.useCallback((a: Search.IFilter<SystemCenter.Types.DetailedAsset>[], b: Search.IFilter<SystemCenter.Types.DetailedAsset>[]) => {
+            return searchStatus === 'uninitiated' ? false : IsSearchBarFiltersEqual(a, b);   
+        },[searchStatus])
 
         React.useEffect(() => {
           return props.GetAddlFields(setAddlFieldCols);
@@ -235,11 +229,9 @@ export namespace DefaultSearch {
             { label: 'Show in Email Subscription', key: 'DisplayEmail', type: 'boolean', isPivotField: false },
         ];
 
-        const FilterEqualityOverride = (a: Search.IFilter<OpenXDA.Types.AssetGroup>[], b: Search.IFilter<OpenXDA.Types.AssetGroup>[]) => {
-            if (searchStatus === 'uninitiated')
-                dispatch(props.Slice.DBSearch({filter: []}))
-            return IsSearchBarFiltersEqual(a, b);   
-        }
+        const FilterEqualityOverride = React.useCallback((a: Search.IFilter<OpenXDA.Types.AssetGroup>[], b: Search.IFilter<OpenXDA.Types.AssetGroup>[]) => {
+            return searchStatus === 'uninitiated' ? false : IsSearchBarFiltersEqual(a, b); 
+        },[searchStatus])
 
         React.useEffect(() => {
           return props.GetAddlFields(setAddlFieldCols);
@@ -285,11 +277,9 @@ export namespace DefaultSearch {
             { label: 'Email', key: 'Email', type: 'string', isPivotField: false },    
         ];
 
-        const FilterEqualityOverride = (a: Search.IFilter<Application.Types.iUserAccount>[], b: Search.IFilter<Application.Types.iUserAccount>[]) => {
-            if (searchStatus === 'uninitiated')
-                dispatch(props.Slice.DBSearch({filter: []}))
-            return IsSearchBarFiltersEqual(a, b);   
-        }
+        const FilterEqualityOverride = React.useCallback((a: Search.IFilter<Application.Types.iUserAccount>[], b: Search.IFilter<Application.Types.iUserAccount>[]) => {
+            return searchStatus === 'uninitiated' ? false : IsSearchBarFiltersEqual(a, b);   
+        },[searchStatus])
 
         React.useEffect(() => {
           return props.GetAddlFields(setAddlFieldCols);
@@ -338,11 +328,9 @@ export namespace DefaultSearch {
         const ascending = useSelector(props.Slice.Ascending)
         const data: OpenXDA.Types.Customer[] = useSelector(props.Slice.SearchResults);
 
-        const FilterEqualityOverride = (a: Search.IFilter<OpenXDA.Types.Customer>[], b: Search.IFilter<OpenXDA.Types.Customer>[]) => {
-            if (searchStatus === 'uninitiated')
-                dispatch(props.Slice.DBSearch({filter: []}))
-            return IsSearchBarFiltersEqual(a, b);   
-        }
+        const FilterEqualityOverride = React.useCallback((a: Search.IFilter<OpenXDA.Types.Customer>[], b: Search.IFilter<OpenXDA.Types.Customer>[]) => {
+            return searchStatus === 'uninitiated' ? false : IsSearchBarFiltersEqual(a, b);   
+        },[searchStatus])
 
         React.useEffect(() => {
           return props.GetAddlFields(setAddlFieldCols);

--- a/react-interactive/src/SearchBar/SearchBar.tsx
+++ b/react-interactive/src/SearchBar/SearchBar.tsx
@@ -163,7 +163,7 @@ export default function SearchBar<T>(props: React.PropsWithChildren<IProps<T>>) 
             localStorage.setItem(`${props.StorageID}.Filters`, JSON.stringify(internalFilters));
             localStorage.setItem(`${props.StorageID}.Search`, debouncedSearch);
         }
-    }, [internalFilters, debouncedSearch, memoizedDefaultColumn, useQuickSearch]);
+    }, [internalFilters, debouncedSearch, memoizedDefaultColumn, useQuickSearch, props.OverrideFilterEquality]);
 
     const deleteFilter = (filterToDelete: Search.IFilter<T>) => {
         setHover(false);

--- a/react-interactive/src/SearchBar/SearchBar.tsx
+++ b/react-interactive/src/SearchBar/SearchBar.tsx
@@ -89,7 +89,7 @@ interface IProps<T> {
      */
     Help?: string
     /**
-     * Overrides filter equality check
+     * Optional override for filter equality check
      */
     OverrideFilterEquality?: (newFilters: Search.IFilter<T>[], oldFilters: Search.IFilter<T>[]) => boolean
 }
@@ -145,7 +145,7 @@ export default function SearchBar<T>(props: React.PropsWithChildren<IProps<T>>) 
     // Sync external filters into internal state when parent changes them
     React.useEffect(() => {
         if (props.Filters === undefined) return;
-        if (filtersEqual(props.Filters, lastPushedFilters.current)) return;
+        if (IsSearchBarFiltersEqual(props.Filters, lastPushedFilters.current)) return;
         setInternalFilters(props.Filters);
     }, [props.Filters]);
 
@@ -153,7 +153,7 @@ export default function SearchBar<T>(props: React.PropsWithChildren<IProps<T>>) 
     React.useEffect(() => {
         const combined = buildCombinedFilters(internalFilters, debouncedSearch, memoizedDefaultColumn, useQuickSearch);
 
-        if (props.OverrideFilterEquality != null ? props.OverrideFilterEquality(combined, lastPushedFilters.current) : filtersEqual(combined, lastPushedFilters.current)) return;
+        if (props.OverrideFilterEquality != null ? props.OverrideFilterEquality(combined, lastPushedFilters.current) : IsSearchBarFiltersEqual(combined, lastPushedFilters.current)) return;
 
         lastPushedFilters.current = combined;
         props.SetFilter(combined);
@@ -399,8 +399,13 @@ function buildCombinedFilters<T>(
     return [...baseFilters, quick];
 }
 
-// Order-independent comparison of two filter arrays
-function filtersEqual<T>(a: Search.IFilter<T>[], b: Search.IFilter<T>[]): boolean {
+/**
+ * Order independent equality check for arrays of filters.
+ * @param a The first array of filters to check.
+ * @param b The second array of filters to check.
+ * @returns true if filters are the same, false if not
+ */
+export function IsSearchBarFiltersEqual<T>(a: Search.IFilter<T>[], b: Search.IFilter<T>[]): boolean {
     if (a === b) return true;
     if (a.length !== b.length) return false;
 

--- a/react-interactive/src/SearchBar/SearchBar.tsx
+++ b/react-interactive/src/SearchBar/SearchBar.tsx
@@ -88,6 +88,10 @@ interface IProps<T> {
      * Optional help message for the filter button
      */
     Help?: string
+    /**
+     * Overrides filter equality check
+     */
+    OverrideFilterEquality?: (newFilters: Search.IFilter<T>[], oldFilters: Search.IFilter<T>[]) => boolean
 }
 
 export interface IOptions { Value: string, Label: string }
@@ -149,7 +153,7 @@ export default function SearchBar<T>(props: React.PropsWithChildren<IProps<T>>) 
     React.useEffect(() => {
         const combined = buildCombinedFilters(internalFilters, debouncedSearch, memoizedDefaultColumn, useQuickSearch);
 
-        if (filtersEqual(combined, lastPushedFilters.current)) return;
+        if (props.OverrideFilterEquality != null ? props.OverrideFilterEquality(combined, lastPushedFilters.current) : filtersEqual(combined, lastPushedFilters.current)) return;
 
         lastPushedFilters.current = combined;
         props.SetFilter(combined);

--- a/react-interactive/src/index.tsx
+++ b/react-interactive/src/index.tsx
@@ -24,7 +24,7 @@
 import Modal from './Modal';
 import Warning from './Warning';
 import SearchBar from './SearchBar/SearchBar';
-import { Search, GetStoredFilters } from './SearchBar/SearchBar';
+import { Search, GetStoredFilters, IsSearchBarFiltersEqual } from './SearchBar/SearchBar';
 import LoadingScreen from './LoadingScreen';
 import LoadingIcon from './LoadingIcon';
 import { ToolTip } from '@gpa-gemstone/react-forms';
@@ -58,6 +58,7 @@ export {
   SearchBar,
   Search,
   GetStoredFilters,
+  IsSearchBarFiltersEqual,
   LoadingScreen,
   LoadingIcon,
   /**


### PR DESCRIPTION
The `SelectPopup`s in use in System Center often load empty and can only be populated by sorting or filtering the empty table. This change would catch uninitiated slices and run a filter-less search (since no filters or quick-searches are present by default anyways) in order to eliminate the need to manually trigger a search on uninitiated slices.