### PR TITLE
QuickSelect Sizing

### DIFF
--- a/common-pages/src/TimeFilter/QuickSelects.tsx
+++ b/common-pages/src/TimeFilter/QuickSelects.tsx
@@ -23,7 +23,7 @@
 //******************************************************************************************************
 
 import * as React from 'react';
-import { getTimeWindowFromFilter, DateTimeSetting, ITimeFilter } from './TimeFilter';
+import { getTimeWindowFromFilter, ITimeFilter } from './TimeFilter';
 import moment from 'moment';
 import momentTZ from 'moment-timezone';
 import { Gemstone } from '@gpa-gemstone/application-typings'
@@ -36,7 +36,6 @@ interface IQuickSelect {
 }
 
 interface IProps {
-    DateTimeSetting: DateTimeSetting,
     Format?: "YYYY-MM-DD" | "HH:mm:ss.SSS" | "MM/DD/YYYY HH:mm:ss.SSS",
     DateUnit?: Gemstone.TSX.Types.DateUnit,
     QuickSelectRange?: Gemstone.TSX.Types.QuickSelectRange
@@ -61,10 +60,10 @@ const QuickSelects = (props: IProps) => {
                 return (
                     <div
                         key={i}
-                        className={getColSize(props.DateTimeSetting, props.SplitSelects ?? false)}
+                        className={(props.SplitSelects ?? false) ? 'col-4' : 'col-2'}
                         style={{
-                            paddingLeft: (props.DateTimeSetting === 'startEnd' ? 0 : (i % 9 == 0 ? 15 : 0)),
-                            paddingRight: (props.DateTimeSetting === 'startEnd' ? 2 : ((i % 18 == 6 || i % 18 == 15) ? 15 : 2)),
+                            paddingLeft: 0,
+                            paddingRight: 2,
                             marginTop: 10
                         }}
                     >
@@ -135,20 +134,6 @@ export function getQuickSelectRange(dateUnit?: Gemstone.TSX.Types.DateUnit) {
         return 'medium'
     if (dateUnit === 'date')
         return 'long'
-}
-
-const getColSize = (dateTimeSetting: DateTimeSetting, splitSelects: boolean) => {
-    if (dateTimeSetting === 'startEnd') {
-        if (splitSelects)
-            return 'col-4'
-        else
-            return 'col-2'
-    }
-
-    if (splitSelects)
-        return 'col-8'
-    else
-        return 'col-4'
 }
 
 //update all quick selects to use new timefilters

--- a/common-pages/src/TimeFilter/StartEndFilter/DateFilter.tsx
+++ b/common-pages/src/TimeFilter/StartEndFilter/DateFilter.tsx
@@ -28,7 +28,6 @@ import { IFilterProps } from './StartEndFilter';
 
 const DateFilter = (props: IFilterProps) => {
     const FirstFallbackBreakpoint = 1050;
-    const SecondFallbackBreakpoint = 541;
 
     const FirstFallbackBreakpointNoQS = 375;
 
@@ -87,7 +86,6 @@ const DateFilter = (props: IFilterProps) => {
                 {props.ShowQuickSelects ?
                     <div className={quickSelectClass}>
                         <QuickSelects
-                            DateTimeSetting={'startEnd'}
                             Timezone={props.Timezone}
                             ActiveQP={props.ActiveQP}
                             SetActiveQP={props.SetActiveQP}
@@ -133,14 +131,13 @@ const DateFilter = (props: IFilterProps) => {
                 {props.ShowQuickSelects ?
                     <div className={quickSelectClass}>
                         <QuickSelects
-                            DateTimeSetting={'startEnd'}
                             Timezone={props.Timezone}
                             ActiveQP={props.ActiveQP}
                             SetActiveQP={props.SetActiveQP}
                             SetFilter={props.SetFilter}
                             Format={props.Format}
                             DateUnit={props.DateUnit}
-                            SplitSelects={props.ContainerWidth < SecondFallbackBreakpoint}
+                            SplitSelects={true}
                             QuickSelectRange={props.QuickSelectRange ?? getQuickSelectRange(props.DateUnit)}
                         />
                     </div> : null}

--- a/common-pages/src/TimeFilter/StartEndFilter/DateTimeLocalFilter.tsx
+++ b/common-pages/src/TimeFilter/StartEndFilter/DateTimeLocalFilter.tsx
@@ -30,6 +30,7 @@ import { IFilterProps } from './StartEndFilter';
 const DateTimeLocalFilter = (props: IFilterProps) => {
     const FirstFallbackBreakpointQS = 1768;
     const SecondFallbackBreakpointQS = 612, FirstFallbacKBreakpointNoQS = 612;
+    const ModalBreakpointQS = 450;
 
     const [showQuickPickModal, setShowQuickPickModal] = React.useState<boolean>(false);
 
@@ -94,7 +95,6 @@ const DateTimeLocalFilter = (props: IFilterProps) => {
                 {props.ShowQuickSelects ?
                     <div className={quickSelectCol}>
                         <QuickSelects
-                            DateTimeSetting={'startEnd'}
                             Timezone={props.Timezone}
                             ActiveQP={props.ActiveQP}
                             SetActiveQP={props.SetActiveQP}
@@ -107,7 +107,7 @@ const DateTimeLocalFilter = (props: IFilterProps) => {
             </div>
         )
     }
-    else if (props.ContainerWidth > SecondFallbackBreakpointQS) {
+    else if (props.ContainerWidth > ModalBreakpointQS) {
         return (
             <div className='row m-0'>
                 <div className={startEndCol}>
@@ -140,7 +140,7 @@ const DateTimeLocalFilter = (props: IFilterProps) => {
                     {props.ShowQuickSelects ?
                         <div className={quickSelectCol}>
                             <QuickSelects
-                                DateTimeSetting={'startEnd'}
+                                SplitSelects={true}
                                 Timezone={props.Timezone}
                                 ActiveQP={props.ActiveQP}
                                 SetActiveQP={props.SetActiveQP}
@@ -202,7 +202,7 @@ const DateTimeLocalFilter = (props: IFilterProps) => {
                         >
                             <div className={quickSelectCol}>
                                 <QuickSelects
-                                    DateTimeSetting={'startEnd'}
+                                    SplitSelects={true}
                                     Timezone={props.Timezone}
                                     ActiveQP={props.ActiveQP}
                                     SetActiveQP={props.SetActiveQP}

--- a/common-pages/src/TimeFilter/StartEndFilter/TimeFilter.tsx
+++ b/common-pages/src/TimeFilter/StartEndFilter/TimeFilter.tsx
@@ -80,7 +80,6 @@ const TimeFilter = (props: IFilterProps) => {
                 </div>
                 {props.ShowQuickSelects ?
                     <QuickSelects
-                        DateTimeSetting={'startEnd'}
                         Timezone={props.Timezone}
                         ActiveQP={props.ActiveQP}
                         SetActiveQP={props.SetActiveQP}
@@ -126,13 +125,13 @@ const TimeFilter = (props: IFilterProps) => {
                 </div>
                 {props.ShowQuickSelects ?
                     <QuickSelects
-                        DateTimeSetting={'startEnd'}
                         Timezone={props.Timezone}
                         ActiveQP={props.ActiveQP}
                         SetActiveQP={props.SetActiveQP}
                         SetFilter={props.SetFilter}
                         Format={props.Format}
                         DateUnit={props.DateUnit}
+                        SplitSelects={true}
                         QuickSelectRange={props.QuickSelectRange ?? getQuickSelectRange(props.DateUnit)}
                     />
                     : null}

--- a/common-pages/src/TimeFilter/WindowFilter/WindowFilter.tsx
+++ b/common-pages/src/TimeFilter/WindowFilter/WindowFilter.tsx
@@ -37,7 +37,6 @@ export interface IProps extends IFilterProps {
 const WindowFilter = (props: IProps) => {
     const DatePickerField = props.Window;
     const DatePickerLabel = props.Window.charAt(0).toUpperCase() + props.Window.slice(1);
-    const filterType = props.Window === 'start' ? 'startWindow' : 'endWindow'
 
     const setter = React.useCallback((record: ITimeWindow) => {
         if (props.Window === 'start') {
@@ -105,7 +104,7 @@ const WindowFilter = (props: IProps) => {
                 </div>
                 <div className='col-8 pt-3'>
                     <QuickSelects
-                        DateTimeSetting={filterType}
+                        SplitSelects={true}
                         Timezone={props.Timezone}
                         ActiveQP={props.ActiveQP}
                         SetActiveQP={props.SetActiveQP}
@@ -148,7 +147,7 @@ const WindowFilter = (props: IProps) => {
                 <div className='row m-0'>
                     <div className='col-12'>
                         <QuickSelects
-                            DateTimeSetting={filterType}
+                            SplitSelects={true}
                             Timezone={props.Timezone}
                             ActiveQP={props.ActiveQP}
                             SetActiveQP={props.SetActiveQP}
@@ -195,7 +194,7 @@ const WindowFilter = (props: IProps) => {
                 <div className='row m-0'>
                     <div className='col-12'>
                         <QuickSelects
-                            DateTimeSetting={filterType}
+                            SplitSelects={true}
                             Timezone={props.Timezone}
                             ActiveQP={props.ActiveQP}
                             SetActiveQP={props.SetActiveQP}

--- a/common-pages/src/TimeFilter/WindowFilter/WindowForm.tsx
+++ b/common-pages/src/TimeFilter/WindowFilter/WindowForm.tsx
@@ -50,7 +50,7 @@ const WindowForm = (props: IProps) => {
     }, [props.Window, props.Format, props.SetActiveQP, props.SetActiveQP])
 
     return (
-        <div className='form-group'>
+        <div className='form-group' style={{ marginBottom: 0 }}>
             <label style={{ width: '100%', position: 'relative', float: "left" }}>
                 Span({props.Window === 'start' ? '+' : '-'})
             </label>


### PR DESCRIPTION
- Remove logic to size QuickSelect columns based on the DateTimeSetting. 
- QuickSelect column sizing is now determined by the parent. 
- Update threshold for putting quickselects in a modal for StartEnd TimeFilters.