### PR TITLE
Document title formatter

### DIFF
--- a/react-interactive/src/Menue/Application/Application.tsx
+++ b/react-interactive/src/Menue/Application/Application.tsx
@@ -46,6 +46,11 @@ interface IProps {
      */
     DefaultPath: string;
 
+    /**
+     * Optional formatter for the browser document title when a page is active.
+     */
+    DocumentTitleFormatter?: (pageName: string, appName: string) => string;
+
     /** 
      * Optional logo URL to display in the top navigation bar 
      */
@@ -127,7 +132,12 @@ const Applications: React.ForwardRefRenderFunction<IApplicationRefs, React.Props
 
     const [activePageLabel, setActivePageLabel] = React.useState<string | null>(null);
     const originalTitle = React.useMemo(() => document.title, []);
-    const pageTitle = React.useMemo(() => activePageLabel ?? originalTitle, [activePageLabel, originalTitle]);
+    const pageTitle = React.useMemo(() => {
+        if (activePageLabel == null)
+            return originalTitle;
+
+        return props.DocumentTitleFormatter?.(activePageLabel, originalTitle) ?? activePageLabel;
+    }, [activePageLabel, originalTitle, props.DocumentTitleFormatter]);
 
     React.useEffect(() => {
         document.title = pageTitle;


### PR DESCRIPTION
- Adds an optional DocumentTitleFormatter prop to the shared Application component.
- Provides the active page name and original application title to the formatter.
- Preserves existing title behavior when no formatter is supplied.
- Enables consumers to format titles as Page - App.